### PR TITLE
Fix behavior of some XPC object functions

### DIFF
--- a/xpc_dictionary.c
+++ b/xpc_dictionary.c
@@ -337,7 +337,11 @@ xpc_dictionary_set_value(xpc_object_t xdict, const char *key, xpc_object_t value
 
 	xo->xo_size++;
 	pair = malloc(sizeof(struct xpc_dict_pair));
-	pair->key = key;
+	size_t len = strlen(key);
+	char* str = malloc(len + 1);
+	strncpy(str, key, len);
+	str[len] = '\0';
+	pair->key = str;
 	pair->value = value;
 	TAILQ_INSERT_TAIL(&xo->xo_dict, pair, xo_link);
 	xpc_retain(value);

--- a/xpc_misc.c
+++ b/xpc_misc.c
@@ -94,6 +94,7 @@ xpc_dictionary_destroy(struct xpc_object *dict)
 
 	TAILQ_FOREACH_SAFE(p, head, xo_link, ptmp) {
 		TAILQ_REMOVE(head, p, xo_link);
+		free(p->key);
 		xpc_object_destroy(p->value);
 		free(p);
 	}
@@ -159,6 +160,12 @@ xpc_object_destroy(struct xpc_object *xo)
 
 	if (xo->xo_xpc_type == _XPC_TYPE_CONNECTION)
 		xpc_connection_destroy(xo);
+
+	if (xo->xo_xpc_type == _XPC_TYPE_STRING)
+		free(xo->xo_u.str);
+
+	if (xo->xo_xpc_type == _XPC_TYPE_DATA)
+		free(xo->xo_u.ptr);
 
 	free(xo);
 }

--- a/xpc_type.c
+++ b/xpc_type.c
@@ -273,7 +273,9 @@ xpc_data_create(const void *bytes, size_t length)
 {
 	xpc_u val;
 
-	val.ptr = (uintptr_t)bytes;
+	void* copy = malloc(length);
+	memcpy(copy, bytes, length);
+	val.ptr = copy;
 	return _xpc_prim_create(_XPC_TYPE_DATA, val, length);
 }
 
@@ -340,8 +342,12 @@ xpc_string_create(const char *string)
 {
 	xpc_u val;
 
-	val.str = string;
-	return _xpc_prim_create(_XPC_TYPE_STRING, val, strlen(string));
+	size_t len = strlen(string);
+	char* str = malloc(len + 1);
+	strncpy(str, string, len);
+	str[len] = '\0';
+	val.str = str;
+	return _xpc_prim_create(_XPC_TYPE_STRING, val, len);
 }
 
 xpc_object_t


### PR DESCRIPTION
In particular:
  * `xpc_string_create` needs to copy its input
  * `xpc_data_create` needs to do the same
  * `xpc_object_destroy` needs to free the memory copied into `xpc_string`s and `xpc_data`s
  * `xpc_dictionary_set_value` needs to copy the key given to it
  * `xpc_dictionary_destroy` needs to free the keys it copied

There's probably a few more, but these are the ones that popped up when I was trying to implement `_CFXPCCreateXPCObjectFromCFObject` in CoreFoundation.

Some of the reasons for the changes:
  * You can see that `xpc_string`s need to copy their input because of the way that they're used. e.g. in `copy_xpc_policy_object` in libSecurity, a temporary CFString is created, an xpc_string is created from it, and then the CFString is released. The only two ways for this to work are if either a) xpc_string retains the CFString (impossible, since libxpc doesn't know about CoreFoundation), or b) xpc_string copies the string given to it
  * In addition, we were actually leaking memory before because `xpc_string_create_with_format` and `xpc_string_create_with_format_and_arguments` (via `vasprintf`) allocate memory for the strings they generate and we weren't freeing that memory when destroying xpc_strings

As for `xpc_data` and `xpc_dictionary`, I'm not entirely sure if these actually need to copy their input, because all the uses of `_CFXPCCreateXPCObjectFromCFObject` together with `CFDictionary`s and `CFData`s I could find seemed to only use the XPC object while the CF counterpart was still alive. However, it's probably not a good idea for the XPC objects to keep pointers into the CF objects, so copying seems like an easy solution.