### PR TITLE
Fix message handling race condition and remove unnecessary checks in nvlist/nvpair

### DIFF
--- a/subr_nvlist.c
+++ b/subr_nvlist.c
@@ -615,7 +615,7 @@ nvlist_xdescriptors(const nvlist_t *nvl, int *descs, int level)
 
 	NVLIST_ASSERT(nvl);
 	PJDLOG_ASSERT(nvl->nvl_error == 0);
-	PJDLOG_ASSERT(level < 3);
+	//PJDLOG_ASSERT(level < 3);
 
 	for (nvp = nvlist_first_nvpair(nvl); nvp != NULL;
 	    nvp = nvlist_next_nvpair(nvl, nvp)) {
@@ -666,7 +666,7 @@ nvlist_xndescriptors(const nvlist_t *nvl, int level)
 
 	NVLIST_ASSERT(nvl);
 	PJDLOG_ASSERT(nvl->nvl_error == 0);
-	PJDLOG_ASSERT(level < 3);
+	//PJDLOG_ASSERT(level < 3);
 
 	ndescs = 0;
 	for (nvp = nvlist_first_nvpair(nvl); nvp != NULL;
@@ -1463,7 +1463,7 @@ void
 nvlist_add_binary(nvlist_t *nvl, const char *name, const void *value,
     size_t size)
 {
-
+	
 	nvlist_addf_binary(nvl, value, size, "%s", name);
 }
 
@@ -1882,6 +1882,8 @@ nvlist_addv_binary(nvlist_t *nvl, const void *value, size_t size,
     const char *namefmt, va_list nameap)
 {
 	nvpair_t *nvp;
+
+	debugf("nvlist_error = %d\n", nvlist_error(nvl));
 
 	if (nvlist_error(nvl) != 0) {
 		RESTORE_ERRNO(nvlist_error(nvl));

--- a/subr_nvpair.c
+++ b/subr_nvpair.c
@@ -690,7 +690,7 @@ nvpair_unpack_binary(bool isbe __unused, nvpair_t *nvp,
 
 	PJDLOG_ASSERT(nvp->nvp_type == NV_TYPE_BINARY);
 
-	if (*leftp < nvp->nvp_datasize || nvp->nvp_datasize == 0) {
+	if (*leftp < nvp->nvp_datasize) {
 		RESTORE_ERRNO(EINVAL);
 		return (NULL);
 	}
@@ -1091,7 +1091,7 @@ nvpair_createv_binary(const void *value, size_t size, const char *namefmt,
 	nvpair_t *nvp;
 	void *data;
 
-	if (value == NULL || size == 0) {
+	if (value == NULL) {
 		RESTORE_ERRNO(EINVAL);
 		return (NULL);
 	}
@@ -1320,7 +1320,7 @@ nvpair_movev_binary(void *value, size_t size, const char *namefmt,
 	nvpair_t *nvp;
 	int serrno;
 
-	if (value == NULL || size == 0) {
+	if (value == NULL) {
 		RESTORE_ERRNO(EINVAL);
 		return (NULL);
 	}

--- a/xpc_connection.c
+++ b/xpc_connection.c
@@ -494,17 +494,16 @@ xpc_connection_recv_message(void *context)
 				debugf("Sync run conn handler");
 				conn->xc_handler(peerx);
 				debugf("Sync conn handler done");
+
+				if (peer->xc_handler) {
+					dispatch_async(peer->xc_target_queue, ^{
+						debugf("Sync result handler");
+						peer->xc_handler(result);
+						debugf("Sync result handler done");
+					});
+				}
 			});
 		}
-
-		if (peer->xc_handler) {
-			dispatch_async(peer->xc_target_queue, ^{
-				debugf("Sync result handler");
-				peer->xc_handler(result);
-				debugf("Sync result handler done");
-			});
-		}
-
 	} else {
 		xpc_connection_set_credentials(conn,
 		    ((struct xpc_object *)result)->xo_audit_token);


### PR DESCRIPTION
Messages weren't being handled for new connections in `xpc_connection_recv_message` because the `if (peer->xc_handler)` check was running before the new peer connection handler (`conn->xc_handler`) could finish running, so there was no message handler set before the check ran.

This PR also removes the unnecessary checks mentioned in darlinghq/darling-security#3.