### PR TITLE
Implement a few XPC dictionary getters and setters

### DIFF
--- a/xpc_dictionary.c
+++ b/xpc_dictionary.c
@@ -383,6 +383,7 @@ xpc_dictionary_set_bool(xpc_object_t xdict, const char *key, bool value)
 	xo = xdict;
 	xotmp = xpc_bool_create(value);
 	xpc_dictionary_set_value(xdict, key, xotmp);
+	xpc_release(xotmp);
 }
 
 void
@@ -393,6 +394,7 @@ xpc_dictionary_set_int64(xpc_object_t xdict, const char *key, int64_t value)
 	xo = xdict;
 	xotmp = xpc_int64_create(value);
 	xpc_dictionary_set_value(xdict, key, xotmp);
+	xpc_release(xotmp);
 }
 
 void
@@ -402,7 +404,8 @@ xpc_dictionary_set_uint64(xpc_object_t xdict, const char *key, uint64_t value)
 
 	xo = xdict;
 	xotmp = xpc_uint64_create(value);
-	xpc_dictionary_set_value(xdict, key, xotmp); 
+	xpc_dictionary_set_value(xdict, key, xotmp);
+	xpc_release(xotmp);
 }
 
 void
@@ -413,6 +416,7 @@ xpc_dictionary_set_string(xpc_object_t xdict, const char *key, const char *value
 	xo = xdict;
 	xotmp = xpc_string_create(value);
 	xpc_dictionary_set_value(xdict, key, xotmp);
+	xpc_release(xotmp);
 }
 
 bool xpc_dictionary_get_bool(xpc_object_t xdict, const char* key) {
@@ -468,17 +472,17 @@ xpc_dictionary_apply(xpc_object_t xdict, xpc_dictionary_applier_t applier)
 	return (true);
 }
 
-const void *
-xpc_dictionary_get_data(xpc_object_t xdict, const char *key, size_t *length)
-{
+const void* xpc_dictionary_get_data(xpc_object_t xdict, const char* key, size_t* length) {
+	xpc_object_t xo = xpc_dictionary_get_value(xdict, key);
+	*length = xpc_data_get_length(xo);
+	return xpc_data_get_bytes_ptr(xo);
+};
 
-}
-
-void
-xpc_dictionary_set_data(xpc_object_t xdict, const char *key, const void *bytes, size_t length)
-{
-
-}
+void xpc_dictionary_set_data(xpc_object_t xdict, const char* key, const void* bytes, size_t length) {
+	xpc_object_t xo = xpc_data_create(bytes, length);
+	xpc_dictionary_set_value(xdict, key, xo);
+	xpc_release(xo);
+};
 
 xpc_connection_t
 xpc_dictionary_get_remote_connection(xpc_object_t xdict)
@@ -497,9 +501,11 @@ xpc_dictionary_set_fd(xpc_object_t xdict, const char *key, int fd)
 {
 }
 
-void
-xpc_dictionary_set_double(xpc_object_t xdict, const char *key, double value) {
-}
+void xpc_dictionary_set_double(xpc_object_t xdict, const char* key, double value) {
+	xpc_object_t xo = xpc_double_create(value);
+	xpc_dictionary_set_value(xdict, key, xo);
+	xpc_release(xo);
+};
 
 const uint8_t *
 xpc_dictionary_get_uuid(xpc_object_t xdict, const char *key)


### PR DESCRIPTION
Implements:
  * `xpc_dictionary_get_data`
  * `xpc_dictionary_set_data`
  * `xpc_dictionary_set_double`

Also, release temporary objects in some setters, since they're retained both when creating them and when adding them to the dictionary (and we only want the dictionary to retain them).